### PR TITLE
chore: use pagination and rate limiting in API calls

### DIFF
--- a/python/github/github_repo_information.py
+++ b/python/github/github_repo_information.py
@@ -137,7 +137,7 @@ if CATEGORY_LABEL_TEAM:
 # Fetch repositories with pagination
 repos_url = f"{base_url}/repos"
 page = 1
-per_page = 3  # Max is 100.
+per_page = 50  # Max is 100.
 num_repos = 0
 
 while True:


### PR DESCRIPTION
- API call to get repos uses pagination to handle large numbers of repos in the org.
  - The aggregation of repo data is still done in memory, but probably won't be an issue even for thousands of repos.
-  All GitHub API calls honor rate limits.
- The code to gather data from individual repos was moved into the new `get_repository_data(..)` function.