### PR TITLE
chore: add github_repo_add_topics.py

### DIFF
--- a/python/github/github_repo_add_topics.py
+++ b/python/github/github_repo_add_topics.py
@@ -1,4 +1,5 @@
 import sys
+import time
 import pandas as pd
 import requests
 import os
@@ -71,6 +72,36 @@ def read_csv_file(csv_path):
     except Exception as e:
         raise CSVFileError(csv_path, f"An unexpected error occurred reading CSV file. Exception: {e}")
 
+def get_rate_limit_reset_time(response):
+    """ Extracts the rate limit reset time from the response headers. """
+    reset_time = int(response.headers.get('X-RateLimit-Reset', 0))
+    return reset_time
+
+def wait_for_rate_limit_reset(reset_time):
+    """ Waits until the rate limit reset time. """
+    wait_time = reset_time - int(time.time()) + 10  # Adding a 10-second buffer.
+    if wait_time > 0:
+        print(f"Rate limit exceeded. Waiting for {wait_time} seconds.")
+        time.sleep(wait_time)
+
+def safe_get_request(url, headers):
+    """ Makes a request and handles rate limiting by waiting until the limit is reset."""
+    response = requests.get(url, headers=headers)
+    if response.status_code == 403 and 'X-RateLimit-Remaining' in response.headers and response.headers['X-RateLimit-Remaining'] == '0':
+        reset_time = get_rate_limit_reset_time(response)
+        wait_for_rate_limit_reset(reset_time)
+        return safe_get_request(url, headers)  # Retry the request
+    return response
+
+def safe_put_request(url, json, headers):
+    """Makes a PUT request and handles rate limiting by waiting until the limit is reset."""
+    response = requests.put(url, json=json, headers=headers)
+    if response.status_code == 403 and 'X-RateLimit-Remaining' in response.headers and response.headers['X-RateLimit-Remaining'] == '0':
+        reset_time = get_rate_limit_reset_time(response)
+        wait_for_rate_limit_reset(reset_time)
+        return safe_put_request(url, json, headers)  # Retry the request
+    return response
+
 def split_topics(topics_str):
     """
     Splits a semicolon-separated string of topics into a list of topics.
@@ -117,7 +148,7 @@ def get_current_repo_topics(base64_encoded_pat, owner, repo):
         'Authorization': f'Basic {base64_encoded_pat}',
         'Accept': 'application/vnd.github.v3+json'
     }
-    response = requests.get(url, headers=request_headers)
+    response = safe_get_request(url, headers=request_headers)
     if response.status_code == 200:
         return response.json().get('names', [])
     else:
@@ -138,7 +169,7 @@ def update_repo_topics(base64_encoded_pat, owner, repo, topics):
         'Authorization': f'Basic {base64_encoded_pat}',
         'Accept': 'application/vnd.github.v3+json'
     }
-    response = requests.put(url, json=payload, headers=request_headers)
+    response = safe_put_request(url, json=payload, headers=request_headers)
     if response.status_code != 200:
         raise TopicUpdateError(owner, repo, response.status_code, response.text)
 

--- a/python/github/github_repo_add_topics.py
+++ b/python/github/github_repo_add_topics.py
@@ -18,10 +18,52 @@ headers = {
     'Accept': 'application/vnd.github.v3+json'
 }
 
+class CSVFileError(Exception):
+    """Base exception class for CSV file-related errors."""
+    def __init__(self, csv_path, message):
+        self.csv_path = csv_path
+        super().__init__(f"{message} Path: '{csv_path}'")
+
+class CSVFileNoPathError(CSVFileError):
+    """Exception raised when the CSV file path is not provided."""
+    def __init__(self, csv_path):
+        message = "The CSV file path was not provided."
+        super().__init__(csv_path, message)
+
+class CSVFileNotFoundError(CSVFileError):
+    """Exception raised when the CSV file is not found."""
+    def __init__(self, csv_path):
+        message = "The CSV file was not found."
+        super().__init__(message)
+
+class CSVFileEmptyError(CSVFileError):
+    """Exception raised when the CSV file is empty."""
+    def __init__(self, csv_path):
+        message = "The CSV file is empty."
+        super().__init__(message)
+
+class CSVFileColumnsError(CSVFileError):
+    """Exception raised when the CSV file does not contain the required columns."""
+    def __init__(self, csv_path, required_columns):
+        message = f"The CSV file must contain the following columns: {', '.join(required_columns)}"
+        super().__init__(csv_path, message)
+
+class CSVFileParseError(CSVFileError):
+    """Exception raised when there is an error parsing the CSV file."""
+    def __init__(self, csv_path):
+        message = "Error parsing the CSV file."
+        super().__init__(message)
+
 def read_csv_file(csv_path):
     """
     Reads a CSV file and returns a DataFrame if it contains the required columns.
+    Raises an exception if there are issues with the CSV file, including if the csv_path is None or empty.
     """
+
+    if csv_path is None or not csv_path.strip():
+        raise CSVFileNoPathError(csv_path)
+    else:
+        csv_path = csv_path.strip()
 
     print(f"Reading CSV file: {csv_path}")
 
@@ -29,21 +71,18 @@ def read_csv_file(csv_path):
         df = pd.read_csv(csv_path)
         required_columns = ['Repo', 'Owner', 'Topics']
         if not all(column in df.columns for column in required_columns):
-            print(f"ERROR: The CSV file must contain the following columns: {', '.join(required_columns)}")
-            return None
+            raise CSVFileColumnsError(csv_path, required_columns)
         return df
     except FileNotFoundError:
-        print("ERROR: The CSV file was not found.")
-        return None
+        raise CSVFileNotFoundError(csv_path)
     except pd.errors.EmptyDataError:
-        print("ERROR: The CSV file is empty.")
-        return None
+        raise CSVFileEmptyError(csv_path)
     except pd.errors.ParserError:
-        print("ERROR: Error parsing the CSV file.")
-        return None
+        raise CSVFileParseError(csv_path)
+    except CSVFileColumnsError:
+        raise
     except Exception as e:
-        print(f"ERROR: An unexpected error occurred reading CSV file. Exception: {e}")
-        return None
+        raise CSVFileError(csv_path, f"An unexpected error occurred reading CSV file. Exception: {e}")
 
 def split_topics(topics_str):
     """
@@ -57,68 +96,114 @@ def split_topics(topics_str):
     else:
         return topics_str.split(';')
 
+class TopicError(Exception):
+    """Base exception class for GitHub topic-related errors."""
+    def __init__(self, action, owner, repo, status_code, message):
+        self.action = action
+        self.owner = owner
+        self.repo = repo
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"Failed to {action} topics for {owner}/{repo}: {status_code}, {message}")
 
-def add_topics_to_repo(owner, repo, topics):
+class TopicFetchError(TopicError):
+    """Exception raised when fetching topics from a GitHub repository fails."""
+    def __init__(self, owner, repo, status_code, message):
+        super().__init__("fetch", owner, repo, status_code, message)
+
+class TopicUpdateError(TopicError):
+    """Exception raised when updating topics for a GitHub repository fails."""
+    def __init__(self, owner, repo, status_code, message):
+        super().__init__("update", owner, repo, status_code, message)
+
+def get_current_repo_topics(owner, repo):
     """
-    Adds topics to a given GitHub repository.
+    Fetches the current topics of a given GitHub repository.
 
     :param owner: The owner of the repository.
     :param repo: The name of the repository.
-    :param topics: A list of topics to add to the repository.
-    :return: True if topics were successfully added, False otherwise.
+    :return: A list of current topics if successful.
+    :raises TopicFetchError: If fetching topics fails.
     """
+    url = f"https://api.github.com/repos/{owner}/{repo}/topics"
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        return response.json().get('names', [])
+    else:
+        raise TopicFetchError(owner, repo, response.status_code, response.text)
 
-    print(f"Adding topics {topics} to repo: {owner}/{repo}")
+def update_repo_topics(owner, repo, topics):
+    """
+    Updates the topics of a given GitHub repository.
 
+    :param owner: The owner of the repository.
+    :param repo: The name of the repository.
+    :param topics: A list of topics to update the repository with.
+    :raises TopicUpdateError: If updating topics fails.
+    """
     url = f"https://api.github.com/repos/{owner}/{repo}/topics"
     payload = {"names": topics}
     response = requests.put(url, json=payload, headers=headers)
+    if response.status_code != 200:
+        raise TopicUpdateError(owner, repo, response.status_code, response.text)
 
-    if response.status_code == 200:
-        print(f"Successfully added topics to {repo}")
-        return True
-    else:
-        print(f"ERROR: Failed to add topics to {repo}: {response.status_code}, {response.text}")
-        return False
+def add_topics_to_repo(owner, repo, new_topics):
+    """
+    Adds topics to a given GitHub repository without removing existing topics.
+
+    :param owner: The owner of the repository.
+    :param repo: The name of the repository.
+    :param new_topics: A list of new topics to add to the repository.
+    :raises TopicError: If adding topics fails.
+    """
+
+    if not new_topics:
+        print(f"Repo: {owner}/{repo}, Skipping. No topics provided.")
+        return
+
+    # Fetch current topics
+    current_topics = get_current_repo_topics(owner, repo)
+
+    # Check if all new topics are already in current topics
+    if set(new_topics).issubset(set(current_topics)):
+        print(f"Repo: {owner}/{repo}, Skipping. All provided topics already exist: {new_topics}")
+        return
+
+    # Merge new topics with current topics without duplicates
+    updated_topics = list(set(current_topics + new_topics))
+
+    print(f"Repo: {owner}/{repo}, Adding topics: {new_topics}")
+
+    # Update the repository's topics
+    update_repo_topics(owner, repo, updated_topics)
 
 def process_csv(csv_path):
     """
     Processes each row in the CSV file to add topics to repositories.
-    Returns True on success, False otherwise.
     """
     df = read_csv_file(csv_path)
-    if df is None:
-        return False
 
-    try:
-        for index, row in df.iterrows():
-            repo = row['Repo']
-            owner = row['Owner']
-            # Assuming topics are separated by semicolon in the CSV
-            topics = split_topics(row['Topics'])
-            success = add_topics_to_repo(owner, repo, topics)
-            if not success:
-                return False
-        return True
-    except Exception as e:
-        print(f"ERROR: An error occurred: {e}")
-        return False
+    for index, row in df.iterrows():
+        repo = row['Repo']
+        owner = row['Owner']
+        topics = split_topics(row['Topics'])
+        add_topics_to_repo(owner, repo, topics)
 
 if __name__ == "__main__":
 
-    # Check if a CSV file path is passed as a command-line argument
-    if len(sys.argv) > 1:
-        csv_path = sys.argv[1]
-    else:
-        csv_path = input("Enter the path to the CSV file: ")
+    try:
 
-    if not csv_path.strip():
-        print("A path to a CSV file is required.")
-        exit(1)
+        # Check if a CSV file path is passed as a command-line argument
+        if len(sys.argv) > 1:
+            csv_path = sys.argv[1]
+        else:
+            csv_path = input("Enter the path to the CSV file: ")
 
-    success = process_csv(csv_path)
-    if success:
+        process_csv(csv_path)
+
         print("Processing completed successfully.")
-    else:
+
+    except Exception as e:
         print("Processing failed.")
+        print(f"ERROR: {e}")
         exit(1)

--- a/python/github/github_repo_add_topics.py
+++ b/python/github/github_repo_add_topics.py
@@ -1,0 +1,124 @@
+import sys
+import pandas as pd
+import requests
+import os
+import base64
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Your personal access token (PAT) from environment variables
+pat = os.getenv('GITHUB_PAT')
+
+# Base64 encode the PAT
+encoded_pat = base64.b64encode(bytes(f'{pat}', 'utf-8')).decode('utf-8')
+headers = {
+    'Authorization': f'Basic {encoded_pat}',
+    'Accept': 'application/vnd.github.v3+json'
+}
+
+def read_csv_file(csv_path):
+    """
+    Reads a CSV file and returns a DataFrame if it contains the required columns.
+    """
+
+    print(f"Reading CSV file: {csv_path}")
+
+    try:
+        df = pd.read_csv(csv_path)
+        required_columns = ['Repo', 'Owner', 'Topics']
+        if not all(column in df.columns for column in required_columns):
+            print(f"ERROR: The CSV file must contain the following columns: {', '.join(required_columns)}")
+            return None
+        return df
+    except FileNotFoundError:
+        print("ERROR: The CSV file was not found.")
+        return None
+    except pd.errors.EmptyDataError:
+        print("ERROR: The CSV file is empty.")
+        return None
+    except pd.errors.ParserError:
+        print("ERROR: Error parsing the CSV file.")
+        return None
+    except Exception as e:
+        print(f"ERROR: An unexpected error occurred reading CSV file. Exception: {e}")
+        return None
+
+def split_topics(topics_str):
+    """
+    Splits a semicolon-separated string of topics into a list of topics.
+
+    :param topics_str: A string containing topics separated by semicolons, None, or NaN.
+    :return: A list of topics.
+    """
+    if topics_str is None or pd.isna(topics_str) or topics_str == '':
+        return []
+    else:
+        return topics_str.split(';')
+
+
+def add_topics_to_repo(owner, repo, topics):
+    """
+    Adds topics to a given GitHub repository.
+
+    :param owner: The owner of the repository.
+    :param repo: The name of the repository.
+    :param topics: A list of topics to add to the repository.
+    :return: True if topics were successfully added, False otherwise.
+    """
+
+    print(f"Adding topics {topics} to repo: {owner}/{repo}")
+
+    url = f"https://api.github.com/repos/{owner}/{repo}/topics"
+    payload = {"names": topics}
+    response = requests.put(url, json=payload, headers=headers)
+
+    if response.status_code == 200:
+        print(f"Successfully added topics to {repo}")
+        return True
+    else:
+        print(f"ERROR: Failed to add topics to {repo}: {response.status_code}, {response.text}")
+        return False
+
+def process_csv(csv_path):
+    """
+    Processes each row in the CSV file to add topics to repositories.
+    Returns True on success, False otherwise.
+    """
+    df = read_csv_file(csv_path)
+    if df is None:
+        return False
+
+    try:
+        for index, row in df.iterrows():
+            repo = row['Repo']
+            owner = row['Owner']
+            # Assuming topics are separated by semicolon in the CSV
+            topics = split_topics(row['Topics'])
+            success = add_topics_to_repo(owner, repo, topics)
+            if not success:
+                return False
+        return True
+    except Exception as e:
+        print(f"ERROR: An error occurred: {e}")
+        return False
+
+if __name__ == "__main__":
+
+    # Check if a CSV file path is passed as a command-line argument
+    if len(sys.argv) > 1:
+        csv_path = sys.argv[1]
+    else:
+        csv_path = input("Enter the path to the CSV file: ")
+
+    if not csv_path.strip():
+        print("A path to a CSV file is required.")
+        exit(1)
+
+    success = process_csv(csv_path)
+    if success:
+        print("Processing completed successfully.")
+    else:
+        print("Processing failed.")
+        exit(1)

--- a/python/github/sample_test_files/add-topics-test.csv
+++ b/python/github/sample_test_files/add-topics-test.csv
@@ -1,4 +1,4 @@
 Owner,Repo,Topics
-Xpirit-Demos,testy-bryanknox-test1,example;sample;test
-Xpirit-Demos,testy-bryanknox-test2,sample;test
+Xpirit-Demos,testy-bryanknox-test1,example;sample;test;testy
+Xpirit-Demos,testy-bryanknox-test2,sample;test;testy
 Xpirit-Demos,testy-bryanknox-test3,

--- a/python/github/sample_test_files/add-topics-test.csv
+++ b/python/github/sample_test_files/add-topics-test.csv
@@ -1,0 +1,4 @@
+Owner,Repo,Topics
+Xpirit-Demos,testy-bryanknox-test1,example;sample;test
+Xpirit-Demos,testy-bryanknox-test2,sample;test
+Xpirit-Demos,testy-bryanknox-test3,

--- a/python/github/sample_test_files/github_repo_add_topics_README.md
+++ b/python/github/sample_test_files/github_repo_add_topics_README.md
@@ -1,0 +1,64 @@
+# GitHub Repository Topics Automation Script
+
+This script allows you to automate the process of adding topics to GitHub repositories by reading the repository details and desired topics from a CSV file.
+
+The script will add the specified topics to the repos if the topics do not already exist. It will not remove any existing topics.
+
+## Prerequisites
+
+Before you start using this script, ensure you have the following installed:
+- Python 3.x
+- `pandas`
+- `requests`
+- `base64`
+- `os`
+- `mimetypes`
+- `python-dotenv`
+
+You can install the necessary Python packages by running:
+
+```sh
+pip install pandas requests python-dotenv
+```
+
+## Configuration
+
+- Personal Access Token (PAT): You need a GitHub Personal Access Token with repo scope. This allows the script to list and read details about repositories, as well as update topics. Follow GitHub's documentation to create a PAT.
+
+- .env File: Create a .env file in the root directory of the script with the following content:
+
+```sh
+GITHUB_PAT=your_personal_access_token_here
+```
+
+Replace `your_personal_access_token_here` with your GitHub Personal Access Token.
+
+## CSV file setup
+Prepare a CSV file where each row represents a GitHub repo that to be targetted.
+
+The CSV file must have the following columns:
+
+Owner: The GitHub organization or user name.
+Repo: The repository name.
+Topics: The topics you want to add to the repository, separated by semicolons (;). Maybe blank if no topics are to be added for the repo on that row.
+
+```csv
+Owner,Repo,Topics
+AnOrgName,a-repository-name,topic1;topic2;topic3
+AnotherOrgName,another-repository-name-2,topicA;topicB
+```
+
+## Usage
+Run the script by executing the following command in your terminal:
+
+```shell
+python github_repo_add_topics.py path_to_your_csv_file.csv
+```
+
+Replace `path_to_your_csv_file.csv` with the path to your CSV file.
+
+If no CSV file path is specified, the script will prompt for the path.
+
+The script will process each repository listed in the CSV file and update its topics accordingly.
+
+The script will add the specified topics to the repos if the topics do not already exist. It will not remove any existing topics.

--- a/python/github/sample_test_files/github_repo_add_topics_README.md
+++ b/python/github/sample_test_files/github_repo_add_topics_README.md
@@ -1,6 +1,6 @@
-# GitHub Repository Topics Automation Script
+# GitHub Repository Add Topics Automation Script
 
-This script allows you to automate the process of adding topics to GitHub repositories by reading the repository details and desired topics from a CSV file.
+The `github_repo_add_topics.py` Python script allows you to automate the process of adding topics to GitHub repositories by reading the repository details and topics to be added from a CSV file.
 
 The script will add the specified topics to the repos if the topics do not already exist. It will not remove any existing topics.
 


### PR DESCRIPTION
Adds a Python script that adds a topics to specified repos.
- Read from CSV file with columns: 
  - Owner (GitHub user or organization)
  - Repo (GitHub repo name)
  - Topics (semicolon delimited list of topic names to add)
 - Path to the CSV to read can be specified on command line or entered in prompt if not specified.